### PR TITLE
Make `Library` conform to `Identifiable`

### DIFF
--- a/Sources/LicenseList/Library.swift
+++ b/Sources/LicenseList/Library.swift
@@ -7,9 +7,15 @@
 
 import Foundation
 
-public struct Library: Hashable {
+public struct Library: Identifiable, Hashable {
+    public let id: UUID = .init()
     public let name: String
     public let licenseBody: String
+
+    public init(name: String, licenseBody: String) {
+        self.name = name
+        self.licenseBody = licenseBody
+    }
 }
 
 extension Library {

--- a/Sources/LicenseList/LicenseListView.swift
+++ b/Sources/LicenseList/LicenseListView.swift
@@ -31,7 +31,7 @@ public struct LicenseListView: View {
 
     public var body: some View {
         List {
-            ForEach(libraries, id: \.name) { library in
+            ForEach(libraries) { library in
                 if useUINavigationController {
                     HStack {
                         libraryButton(library)


### PR DESCRIPTION
In the `LicenseListView`, libraries are currently identified using `id: \.name`. This can cause issues when there are libraries with duplicate names. This PR addresses the issue by:

1. Making the `Library` struct conform to the `Identifiable` protocol. Each `Library` instance now has a unique `id` in the form of a `UUID`. While these UUIDs change with every instance creation, it's important to note that within the lifecycle of the `LicenseListView`, the `libraries: [Library]` array is initialized once and does not change. Therefore, there won't be any issues arising from changing UUIDs during the view's lifecycle.
2. Modifying the `ForEach` in `LicenseListView` to iterate over libraries without explicitly using `id: \.name`.