### PR TITLE
Fixed a bug caused by hyperlinks

### DIFF
--- a/Sources/LicenseList/LegacyLicenseView.swift
+++ b/Sources/LicenseList/LegacyLicenseView.swift
@@ -50,7 +50,6 @@ public struct LegacyLicenseView: View {
     }
 
     private func resolve(_ inputText: String) -> [LegacyLicenseSentence] {
-        let pattern: String = "https?://[A-Za-z0-9\\.\\-\\[\\]!@#$%&=+/?:_]+"
-        return inputText.split(pattern)
+        return inputText.split(URL.regexPattern)
     }
 }

--- a/Sources/LicenseList/LegacyLicenseView.swift
+++ b/Sources/LicenseList/LegacyLicenseView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct LegacyLicenseView: View {
-    @State private var sentences = [LegacyLicenseSentence]()
+    @State private var lines = [[LegacyLicenseSentence]]()
 
     private let library: Library
 
@@ -18,13 +18,30 @@ public struct LegacyLicenseView: View {
 
     public var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
-                ForEach(sentences, id: \.body) { sentence in
-                    if sentence.isHyperLink {
-                        hyperLinkText(sentence.body)
-                    } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(lines.indices, id: \.self) { index in
+                    if lines[index].count == 1,
+                       let sentence = lines[index].first {
                         Text(sentence.body)
                             .font(.caption)
+                    } else {
+                        lines[index].reduce(Text("")) { result, sentence in
+                            if sentence.isHyperLink {
+                                return result + Text(sentence.body)
+                                    .font(.caption)
+                                    .foregroundColor(Color.blue)
+                            } else {
+                                return result + Text(sentence.body)
+                                    .font(.caption)
+                            }
+                        }
+                        .onTapGesture {
+                            if let linkText = lines[index].first(where: { $0.isHyperLink })?.body,
+                               let url = URL(string: linkText),
+                               UIApplication.shared.canOpenURL(url) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
                     }
                 }
             }
@@ -32,24 +49,14 @@ public struct LegacyLicenseView: View {
             .padding()
         }
         .onAppear {
-            sentences = resolve(library.licenseBody)
+            lines = resolve(library.licenseBody)
         }
         .navigationBarTitleInlineIfPossible(library.name)
     }
 
-    private func hyperLinkText(_ linkText: String) -> some View {
-        Text(linkText)
-            .font(.caption)
-            .foregroundColor(Color.blue)
-            .onTapGesture {
-                if let url = URL(string: linkText),
-                   UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url)
-                }
-            }
-    }
-
-    private func resolve(_ inputText: String) -> [LegacyLicenseSentence] {
-        return inputText.split(URL.regexPattern)
+    private func resolve(_ inputText: String) -> [[LegacyLicenseSentence]] {
+        return inputText
+            .components(separatedBy: .newlines)
+            .map { $0.split(URL.regexPattern) }
     }
 }

--- a/Sources/LicenseList/LicenseView.swift
+++ b/Sources/LicenseList/LicenseView.swift
@@ -37,10 +37,9 @@ public struct LicenseView: View {
 
     private func attribute(_ inputText: String) -> AttributedString {
         var attributedText = AttributedString(inputText)
-        let pattern: String = "https?://[A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;%=]+"
-        let urls: [URL?] = inputText.match(pattern)
+        let urls: [URL?] = inputText.match(URL.regexPattern)
             .map { URL(string: String(inputText[$0])) }
-        let ranges = attributedText.match(pattern)
+        let ranges = attributedText.match(URL.regexPattern)
         for case (let range, let url?) in zip(ranges, urls) {
             attributedText[range].link = url
         }

--- a/Sources/LicenseList/URL+Extension.swift
+++ b/Sources/LicenseList/URL+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  URL+Extension.swift
+//  
+//
+//  Created by ky0me22 on 2023/09/26.
+//
+
+import Foundation
+
+extension URL {
+    static let regexPattern = "https?://[A-Za-z0-9-.!@#$%&=+/?:_~]+"
+}


### PR DESCRIPTION
### 1. Fixed URL pattern of regular expression
The link in parentheses was broken.

**Before**
![Simulator Screenshot - iPhone 14 Pro - 2023-09-27 at 12 11 34](https://github.com/cybozu/LicenseList/assets/19896354/5963db1d-0824-4a7d-bbef-d39ed933938e)

**After**
![Simulator Screenshot - iPhone 14 Pro - 2023-09-27 at 12 10 38](https://github.com/cybozu/LicenseList/assets/19896354/e3680cc3-0265-4927-b141-1e2f77165d0b)

### 2. Fixed layout collapse of LegacyLicenseView caused by hyperlinks

**Before**
![Simulator Screenshot - iPhone 12 Pro - 2023-09-27 at 12 05 35](https://github.com/cybozu/LicenseList/assets/19896354/3419579e-0c1e-46ba-b0a9-cf749e7b3474)

**After**
![Simulator Screenshot - iPhone 12 Pro - 2023-09-27 at 12 04 47](https://github.com/cybozu/LicenseList/assets/19896354/a6ea6f5d-1eb9-4ec8-890f-10597b129266)