### PR TITLE
[fix] Fixed an issue where the plugin could not be built on Xcode Cloud.

### DIFF
--- a/Sources/SourcePackagesParser/SourcePackagesParser.swift
+++ b/Sources/SourcePackagesParser/SourcePackagesParser.swift
@@ -100,7 +100,7 @@ final class SourcePackagesParser {
             let data = try PropertyListSerialization.data(fromPropertyList: dict,
                                                           format: .xml,
                                                           options: .zero)
-            try data.write(to: saveURL, options: .atomic)
+            try data.write(to: saveURL)
         } catch {
             throw SPPError.couldNotExportLicenseList
         }


### PR DESCRIPTION
## Cause.
Error when using the .atomic option when generating files in the plugin's working directory.

The following PR is a solution to the same problem. 
https://github.com/mac-cain13/R.swift/pull/879

The LicenseProvider then generates the file without passing any options to "Data.write(to:options:)". The default options for this method are "[]". 
https://github.com/zunda-pixel/LicenseProvider/blob/main/Sources/LicenseProviderExec/main.swift#L61

## Changes.
Removed option argument from "Data.write(to:options:)".