### PR TITLE
Allows the Style of LicenseListView and LicenseView to be customized.

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 17.0;
 			};
 			name = Debug;
 		};
@@ -383,6 +384,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				TVOS_DEPLOYMENT_TARGET = 17.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -410,13 +412,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cybozu.swiftui.examples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,3";
 			};
 			name = Debug;
 		};
@@ -443,13 +445,13 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cybozu.swiftui.examples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,3";
 			};
 			name = Release;
 		};

--- a/Examples/ExamplesForSwiftUI/ContentView.swift
+++ b/Examples/ExamplesForSwiftUI/ContentView.swift
@@ -14,7 +14,9 @@ struct ContentView: View {
             NavigationLink("License") {
                 LicenseListView()
                     .navigationTitle("LICENSE")
+                    #if os(iOS)
                     .navigationBarTitleDisplayMode(.inline)
+                    #endif
             }
         }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let package = Package(
     name: "LicenseList",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v15),
+        .tvOS(.v17),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Generate a list of licenses for the Swift Package libraries that your app depend
 
 - Development with Xcode 15.4+
 - Written in Swift 5.9
-- Compatible with iOS 15.0+
+- Compatible with iOS 15.0+, tvOS 17.0+
 
 ## Documentation
 

--- a/Sources/LicenseList/EnvironmentValues+Extensions.swift
+++ b/Sources/LicenseList/EnvironmentValues+Extensions.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+private struct LicenseListViewStyleKey: EnvironmentKey {
+    static let defaultValue: any LicenseListViewStyle = DefaultLicenseListViewStyle()
+}
+
+private struct LicenseViewStyleKey: EnvironmentKey {
+    static let defaultValue: any LicenseViewStyle = DefaultLicenseViewStyle()
+}
+
+extension EnvironmentValues {
+    var licenseListViewStyle: any LicenseListViewStyle {
+        get { self[LicenseListViewStyleKey.self] }
+        set { self[LicenseListViewStyleKey.self] = newValue }
+    }
+
+    var licenseViewStyle: any LicenseViewStyle {
+        get { self[LicenseViewStyleKey.self] }
+        set { self[LicenseViewStyleKey.self] = newValue }
+    }
+}

--- a/Sources/LicenseList/LicenseListView.swift
+++ b/Sources/LicenseList/LicenseListView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// A view that presents license views in a list format.
 public struct LicenseListView: View {
-    @Environment(\.licenseViewStyle) private var licenseViewStyle: LicenseViewStyle
+    @Environment(\.licenseListViewStyle) private var _licenseListViewStyle
+    @Environment(\.licenseViewStyle) private var _licenseViewStyle
 
     let libraries = Library.libraries
     let navigationHandler: ((Library) -> Void)?
@@ -17,31 +18,10 @@ public struct LicenseListView: View {
 
     /// The content and behavior of the license list view.
     public var body: some View {
-        List {
-            ForEach(libraries) { library in
-                if let navigationHandler {
-                    HStack {
-                        Button {
-                            navigationHandler(library)
-                        } label: {
-                            Text(library.name)
-                        }
-                        .foregroundColor(.primary)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.subheadline.bold())
-                            .foregroundColor(Color(.systemGray3))
-                    }
-                } else {
-                    NavigationLink {
-                        LicenseView(library: library)
-                            .licenseViewStyle(licenseViewStyle)
-                    } label: {
-                        Text(library.name)
-                    }
-                }
-            }
-        }
-        .listStyle(.insetGrouped)
+        AnyView(_licenseListViewStyle.makeBody(configuration: .init(
+            libraries: libraries,
+            navigationHandler: navigationHandler,
+            licenseViewStyle: _licenseViewStyle
+        )))
     }
 }

--- a/Sources/LicenseList/LicenseListViewController.swift
+++ b/Sources/LicenseList/LicenseListViewController.swift
@@ -8,8 +8,11 @@ import SwiftUI
 /// - The list is sorted alphabetically by library name.
 /// - Selecting each library will open a details page where you can view the license body.
 public class LicenseListViewController: UIViewController {
+    /// The style that specifies behavior of license list view.
+    public var licenseListViewStyle: any LicenseListViewStyle = .automatic
+
     /// The style that specifies behavior of license views.
-    public var licenseViewStyle: LicenseViewStyle = .plain
+    public var licenseViewStyle: any LicenseViewStyle = .automatic
 
     /// Creates a license list view controller.
     public init() {
@@ -40,7 +43,11 @@ public class LicenseListViewController: UIViewController {
 
     private func navigateTo(library: Library) {
         let hostingController = UIHostingController(
-            rootView: LicenseView(library: library).licenseViewStyle(licenseViewStyle)
+            rootView: AnyView(
+                LicenseView(library: library)
+                    .licenseListViewStyle(licenseListViewStyle)
+                    .licenseViewStyle(licenseViewStyle)
+            )
         )
         hostingController.title = library.name
         self.navigationController?.pushViewController(hostingController, animated: true)

--- a/Sources/LicenseList/LicenseListViewStyle.swift
+++ b/Sources/LicenseList/LicenseListViewStyle.swift
@@ -38,7 +38,7 @@ public struct PlainLicenseListViewStyle: LicenseListViewStyle {
                         Spacer()
                         Image(systemName: "chevron.right")
                             .font(.subheadline.bold())
-                            .foregroundColor(Color(.systemGray3))
+                            .foregroundColor(chevronGray)
                     }
                 } else {
                     NavigationLink {
@@ -50,7 +50,17 @@ public struct PlainLicenseListViewStyle: LicenseListViewStyle {
                 }
             }
         }
+        #if os(iOS)
         .listStyle(.insetGrouped)
+        #endif
+    }
+
+    private var chevronGray: Color {
+        #if os(iOS)
+        Color(.systemGray3)
+        #else
+        Color.gray
+        #endif
     }
 }
 

--- a/Sources/LicenseList/LicenseListViewStyle.swift
+++ b/Sources/LicenseList/LicenseListViewStyle.swift
@@ -1,8 +1,15 @@
 import SwiftUI
 
+/// The properties of a license list view.
 public struct LicenseListViewStyleConfiguration {
+    /// An Array of library information.
     public let libraries: [Library]
+
+    /// The closure to navigate for the given ``Library``.
+    /// This is used when controlling navigation using a UINavigationController.
     public let navigationHandler: ((Library) -> Void)?
+
+    /// The style that conforms to LicenseViewStyle.
     public let licenseViewStyle: any LicenseViewStyle
 
     init(
@@ -16,15 +23,34 @@ public struct LicenseListViewStyleConfiguration {
     }
 }
 
+/// A type that applies standard interaction behavior and a custom appearance to all license list views within a view hierarchy.
+///
+/// To configure the current license list view style for a view hierarchy, use the ``SwiftUI/View/licenseListViewStyle(_:)`` modifier.
+/// Specify a style that conforms to LicenseListViewStyle when creating a license list view that uses the standard its interaction behavior defined for each platform.
 public protocol LicenseListViewStyle: Sendable {
+    /// A view that represents the body of a license list view.
     associatedtype Body: View
 
-    @MainActor 
-    func makeBody(configuration: LicenseListViewStyleConfiguration) -> Body
+    /// Creates a view that represents the body of a license list view.
+    /// - Parameters:
+    ///   - configuration: The properties of the license list view.
+    ///
+    /// The system calls this method for each ``LicenseListView`` instance in a view hierarchy where this style is the current license list view style.
+    @MainActor func makeBody(configuration: Configuration) -> Body
+
+    /// The properties of a license list view.
+    typealias Configuration = LicenseListViewStyleConfiguration
 }
 
+/// A license list view style that displays the list of libraries.
+///
+/// Selecting a library name in the list will navigate to the library details view.
+/// You can also use ``PlainLicenseListViewStyle/plain`` to construct this style.
 public struct PlainLicenseListViewStyle: LicenseListViewStyle {
-    public func makeBody(configuration: LicenseListViewStyleConfiguration) -> some View {
+    /// Creates a plain license list view style.
+    public init() {}
+
+    public func makeBody(configuration: PlainLicenseListViewStyle.Configuration) -> some View {
         List {
             ForEach(configuration.libraries) { library in
                 if let navigationHandler = configuration.navigationHandler {
@@ -65,17 +91,29 @@ public struct PlainLicenseListViewStyle: LicenseListViewStyle {
 }
 
 public extension LicenseListViewStyle where Self == PlainLicenseListViewStyle {
+    /// A license list view style that displays the list of libraries.
+    ///
+    /// Selecting a library name in the list will navigate to the library details view.
+    /// To apply this style to a license list view, use the ``SwiftUI/View/licenseListViewStyle(_:)`` modifier.
     static var plain: Self { Self() }
 }
 
+/// The default license list view style.
+///
+/// You can also use ``LicenseListViewStyle/automatic`` to construct this style.
 public struct DefaultLicenseListViewStyle: LicenseListViewStyle {
+    /// Creates a default license list view style.
     public init() {}
 
-    public func makeBody(configuration: LicenseListViewStyleConfiguration) -> some View {
+    public func makeBody(configuration: DefaultLicenseListViewStyle.Configuration) -> some View {
         PlainLicenseListViewStyle().makeBody(configuration: configuration)
     }
 }
 
 public extension LicenseListViewStyle where Self == DefaultLicenseListViewStyle {
+    /// The default license list style.
+    ///
+    /// You can override a license list view's style.
+    /// To apply the default style to a license list view, use the ``SwiftUI/View/licenseListViewStyle(_:)`` modifier.
     static var automatic: Self { Self() }
 }

--- a/Sources/LicenseList/LicenseListViewStyle.swift
+++ b/Sources/LicenseList/LicenseListViewStyle.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+public struct LicenseListViewStyleConfiguration {
+    public let libraries: [Library]
+    public let navigationHandler: ((Library) -> Void)?
+    public let licenseViewStyle: any LicenseViewStyle
+
+    init(
+        libraries: [Library],
+        navigationHandler: ((Library) -> Void)?,
+        licenseViewStyle: any LicenseViewStyle
+    ) {
+        self.libraries = libraries
+        self.navigationHandler = navigationHandler
+        self.licenseViewStyle = licenseViewStyle
+    }
+}
+
+public protocol LicenseListViewStyle: Sendable {
+    associatedtype Body: View
+
+    @MainActor 
+    func makeBody(configuration: LicenseListViewStyleConfiguration) -> Body
+}
+
+public struct PlainLicenseListViewStyle: LicenseListViewStyle {
+    public func makeBody(configuration: LicenseListViewStyleConfiguration) -> some View {
+        List {
+            ForEach(configuration.libraries) { library in
+                if let navigationHandler = configuration.navigationHandler {
+                    HStack {
+                        Button {
+                            navigationHandler(library)
+                        } label: {
+                            Text(library.name)
+                        }
+                        .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.subheadline.bold())
+                            .foregroundColor(Color(.systemGray3))
+                    }
+                } else {
+                    NavigationLink {
+                        LicenseView(library: library)
+                            .environment(\.licenseViewStyle, configuration.licenseViewStyle)
+                    } label: {
+                        Text(library.name)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+}
+
+public extension LicenseListViewStyle where Self == PlainLicenseListViewStyle {
+    static var plain: Self { Self() }
+}
+
+public struct DefaultLicenseListViewStyle: LicenseListViewStyle {
+    public init() {}
+
+    public func makeBody(configuration: LicenseListViewStyleConfiguration) -> some View {
+        PlainLicenseListViewStyle().makeBody(configuration: configuration)
+    }
+}
+
+public extension LicenseListViewStyle where Self == DefaultLicenseListViewStyle {
+    static var automatic: Self { Self() }
+}

--- a/Sources/LicenseList/LicenseView.swift
+++ b/Sources/LicenseList/LicenseView.swift
@@ -9,7 +9,7 @@ public struct LicenseView: View {
 
     private let library: Library
 
-    /// Creates new license list view with the specified library.
+    /// Creates new license view with the specified library.
     /// - Parameters:
     ///   - library: The library to use in this view.
     public init(library: Library) {

--- a/Sources/LicenseList/LicenseView.swift
+++ b/Sources/LicenseList/LicenseView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 public struct LicenseView: View {
     @State private var attributedLicenseBody = AttributedString(stringLiteral: "")
 
+    @Environment(\.licenseViewStyle) private var _licenseViewStyle
     @Environment(\.openURL) private var openURL: OpenURLAction
-    @Environment(\.licenseViewStyle) private var licenseViewStyle: LicenseViewStyle
 
     private let library: Library
 
@@ -18,20 +18,13 @@ public struct LicenseView: View {
 
     /// The content and behavior of the license view.
     public var body: some View {
-        ScrollView {
-            Text(attributedLicenseBody)
-                .font(.caption)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
-                .onAppear {
-                    attributedLicenseBody = attribute(library.licenseBody)
-                }
-        }
-        .navigationBarTitle(library.name)
-        ._licenseViewStyle(licenseViewStyle) {
-            if let url = library.url {
-                openURL(url)
-            }
+        AnyView(_licenseViewStyle.makeBody(configuration: .init(
+            library: library,
+            attributedLicenseBody: attributedLicenseBody,
+            openURL: { openURL($0) }
+        )))
+        .onAppear {
+            attributedLicenseBody = attribute(library.licenseBody)
         }
     }
 

--- a/Sources/LicenseList/LicenseViewStyle.swift
+++ b/Sources/LicenseList/LicenseViewStyle.swift
@@ -1,9 +1,17 @@
 import SwiftUI
 
+/// The properties of a license view.
 public struct LicenseViewStyleConfiguration {
+    /// The library information.
     public let library: Library
+
+    /// The number of lines in the license body.
     public let numberOfLines: Int
+
+    /// The license body where in-text links work.
     public let attributedLicenseBody: AttributedString
+
+    /// An action that opens a URL.
     public let openURL: (URL) -> Void
 
     init(
@@ -18,15 +26,34 @@ public struct LicenseViewStyleConfiguration {
     }
 }
 
+/// A type that applies standard interaction behavior and a custom appearance to all license views within a view hierarchy.
+///
+/// To configure the current license view style for a view hierarchy, use the ``SwiftUI/View/licenseViewStyle(_:)`` modifier.
+/// Specify a style that conforms to LicenseViewStyle when creating a license view that uses the standard its interaction behavior defined for each platform.
 public protocol LicenseViewStyle: Sendable {
+    /// A view that represents the body of a license view.
     associatedtype Body: View
 
-    @MainActor
-    func makeBody(configuration: LicenseViewStyleConfiguration) -> Body
+    /// Creates a view that represents the body of a license view.
+    /// - Parameters:
+    ///   - configuration: The properties of the license view.
+    ///
+    /// The system calls this method for each ``LicenseView`` instance in a view hierarchy where this style is the current license view style.
+    @MainActor func makeBody(configuration: Configuration) -> Body
+
+    /// The properties of a license view.
+    typealias Configuration = LicenseViewStyleConfiguration
 }
 
+/// A license view style that only displays the license body.
+///
+/// Links in the text will open in external apps.
+/// You can also use ``PlainLicenseViewStyle/plain`` to construct this style.
 public struct PlainLicenseViewStyle: LicenseViewStyle {
-    public func makeBody(configuration: LicenseViewStyleConfiguration) -> some View {
+    /// Creates a plain license view style.
+    public init() {}
+
+    public func makeBody(configuration: PlainLicenseViewStyle.Configuration) -> some View {
         ScrollView {
             Text(configuration.attributedLicenseBody)
                 .font(.caption)
@@ -42,11 +69,24 @@ public struct PlainLicenseViewStyle: LicenseViewStyle {
 }
 
 public extension LicenseViewStyle where Self == PlainLicenseViewStyle {
+    /// A license view style that only displays the license body.
+    ///
+    /// Links in the text will open in external apps.
+    /// To apply this style to a license view, use the ``SwiftUI/View/licenseViewStyle(_:)`` modifier.
     static var plain: Self { Self() }
 }
 
+/// A license view style with repository anchor link.
+///
+/// This style is based on the plain style.
+/// Links in the text will open in external apps.
+/// In addition, a button linking to the library's repository places in the right corner of the navigation bar.
+/// You can also use ``WithRepositoryAnchorLinkLicenseViewStyle/withRepositoryAnchorLink`` to construct this style.
 public struct WithRepositoryAnchorLinkLicenseViewStyle: LicenseViewStyle {
-    public func makeBody(configuration: LicenseViewStyleConfiguration) -> some View {
+    /// Creates a license view style with repository anchor link.
+    public init() {}
+
+    public func makeBody(configuration: WithRepositoryAnchorLinkLicenseViewStyle.Configuration) -> some View {
         PlainLicenseViewStyle()
             .makeBody(configuration: configuration)
             .navigationBarRepositoryAnchorLink {
@@ -58,18 +98,37 @@ public struct WithRepositoryAnchorLinkLicenseViewStyle: LicenseViewStyle {
 }
 
 public extension LicenseViewStyle where Self == WithRepositoryAnchorLinkLicenseViewStyle {
+    /// A license view style with repository anchor link.
+    ///
+    /// This style is based on the plain style.
+    /// Links in the text will open in external apps.
+    /// In addition, a button linking to the library's repository places in the right corner of the navigation bar.
+    /// To apply this style to a license view, or to a view that contains license views, use the ``SwiftUI/View/licenseViewStyle(_:)`` modifier.
     static var withRepositoryAnchorLink: Self { Self() }
 }
 
+/// The default license view style.
+///
+/// You can also use ``LicenseViewStyle/automatic`` to construct this style.
 public struct DefaultLicenseViewStyle: LicenseViewStyle {
+    /// Creates a default license view style.
     public init() {}
 
-    public func makeBody(configuration: LicenseViewStyleConfiguration) -> some View {
+    /// Creates a view that represents the body of a license view.
+    /// - Parameters:
+    ///   - configuration: The properties of the license view.
+    ///
+    /// The system calls this method for each ``LicenseView`` instance in a view hierarchy where this style is the current license view style.
+    public func makeBody(configuration: DefaultLicenseViewStyle.Configuration) -> some View {
         PlainLicenseViewStyle().makeBody(configuration: configuration)
     }
 }
 
 public extension LicenseViewStyle where Self == DefaultLicenseViewStyle {
+    /// The default license style.
+    ///
+    /// You can override a license view's style.
+    /// To apply the default style to a license view, or to a view that contains license views, use the ``SwiftUI/View/licenseViewStyle(_:)`` modifier.
     static var automatic: Self { Self() }
 }
 

--- a/Sources/LicenseList/LicenseViewStyle.swift
+++ b/Sources/LicenseList/LicenseViewStyle.swift
@@ -31,7 +31,9 @@ public struct PlainLicenseViewStyle: LicenseViewStyle {
             Text(configuration.attributedLicenseBody)
                 .font(.caption)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .scrollableTextIfNeeded(numberOfLines: configuration.numberOfLines, font: .caption)
+                #if os(tvOS)
+                .scrollableText(numberOfLines: configuration.numberOfLines, font: .caption)
+                #endif
                 .padding()
         }
         .clipShape(Rectangle())
@@ -72,6 +74,7 @@ public extension LicenseViewStyle where Self == DefaultLicenseViewStyle {
 }
 
 // Style & Modifier For tvOS
+#if os(tvOS)
 private struct DummyFocusButtonStyle: ButtonStyle {
     let text: String
     let font: Font
@@ -84,7 +87,7 @@ private struct DummyFocusButtonStyle: ButtonStyle {
     }
 }
 
-private struct ScrollableTextIfNeededViewModifier: ViewModifier {
+private struct ScrollableTextViewModifier: ViewModifier {
     private let numberOfButtons: Int
     private let text: String
     private let font: Font
@@ -96,7 +99,6 @@ private struct ScrollableTextIfNeededViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        #if os(tvOS)
         ZStack(alignment: .topLeading) {
             content
             VStack {
@@ -106,14 +108,12 @@ private struct ScrollableTextIfNeededViewModifier: ViewModifier {
                 }
             }
         }
-        #else
-        content
-        #endif
     }
 }
 
 private extension View {
-    func scrollableTextIfNeeded(numberOfLines: Int, font: Font) -> some View {
-        self.modifier(ScrollableTextIfNeededViewModifier(numberOfLines: numberOfLines, font: font))
+    func scrollableText(numberOfLines: Int, font: Font) -> some View {
+        self.modifier(ScrollableTextViewModifier(numberOfLines: numberOfLines, font: font))
     }
 }
+#endif

--- a/Sources/LicenseList/View+Extensions.swift
+++ b/Sources/LicenseList/View+Extensions.swift
@@ -2,11 +2,26 @@ import SwiftUI
 
 extension View {
     /// Sets the style for license list view within this view.
+    ///
+    /// Use this modifier to set a specific style for license list view instances within a view:
+    ///
+    /// ```swift
+    /// LicenseListView()
+    ///     .licenseListViewStyle(.plain)
+    /// ```
     public func licenseListViewStyle(_ style: some LicenseListViewStyle) -> some View {
         self.environment(\.licenseListViewStyle, style)
     }
 
     /// Sets the style for license views within this view.
+    ///
+    /// Use this modifier to set a specific style for license view instances within a view:
+    ///
+    /// ```swift
+    /// ForEach(Library.libraries) { library in
+    ///     LicenseView(library: library)
+    /// }
+    /// .licenseViewStyle(.plain)
     public func licenseViewStyle(_ style: some LicenseViewStyle) -> some View {
         self.environment(\.licenseViewStyle, style)
     }

--- a/Sources/LicenseList/View+Extensions.swift
+++ b/Sources/LicenseList/View+Extensions.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 
 extension View {
+    /// Sets the style for license list view within this view.
+    public func licenseListViewStyle(_ style: some LicenseListViewStyle) -> some View {
+        self.environment(\.licenseListViewStyle, style)
+    }
+
+    /// Sets the style for license views within this view.
+    public func licenseViewStyle(_ style: some LicenseViewStyle) -> some View {
+        self.environment(\.licenseViewStyle, style)
+    }
+
     func navigationBarRepositoryAnchorLink(action: @escaping () -> Void) -> some View {
         self.toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -11,21 +21,5 @@ extension View {
                 }
             }
         }
-    }
-
-    func _licenseViewStyle(_ style: LicenseViewStyle, action: @escaping () -> Void) -> some View {
-        Group {
-            switch style {
-            case .plain:
-                self
-            case .withRepositoryAnchorLink:
-                self.navigationBarRepositoryAnchorLink(action: action)
-            }
-        }
-    }
-
-    /// Sets the style for license views within this view.
-    public func licenseViewStyle(_ style: LicenseViewStyle) -> some View {
-        self.environment(\.licenseViewStyle, style)
     }
 }


### PR DESCRIPTION
## LicenseList provides the following APIs.

- LicenseListViewStyle (protocol)
  - `.licenseListViewStyle(_:)` (ViewModifier)
  - PlainLicenseListViewStyle / `.plain`
  - DefaultLicenseListViewStyle / `.automatic`
  - LicenseListViewStyleConfiguration
- LicenseViewStyle (protocol)
  - `licenseViewStyle(_:)` (ViewModifier)
  - PlainLicenseViewStyle / `.plain`
  - WithRepositoryAnchorLinkLicenseViewStyle / `.withRepositoryAnchorLink`
  - DefaultLicenseViewStyle / `.automatic`
  - LicenseViewStyleConfiguration

## And LicenseList supports tvOS in addition to iOS/iPadOS by default.

**tvOS DEMO**

![untitled](https://github.com/user-attachments/assets/9cb4e38a-c840-4a76-a6ee-694455429f38)
