### PR TITLE
Added workaround for mac catalyst & supported mac catalyst.

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		188460622C37EDE2005C370A /* LicenseList */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = LicenseList; path = ..; sourceTree = "<group>"; };
+		188707F02CF5882D00E5A6CF /* ExamplesForSwiftUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ExamplesForSwiftUI.entitlements; sourceTree = "<group>"; };
 		18FCC4412C37E4550052500D /* ExamplesForSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExamplesForSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18FCC4432C37E4550052500D /* ExamplesForSwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesForSwiftUIApp.swift; sourceTree = "<group>"; };
 		18FCC4452C37E4550052500D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -81,6 +82,7 @@
 		18FCC4422C37E4550052500D /* ExamplesForSwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				188707F02CF5882D00E5A6CF /* ExamplesForSwiftUI.entitlements */,
 				18FCC4432C37E4550052500D /* ExamplesForSwiftUIApp.swift */,
 				18FCC4452C37E4550052500D /* ContentView.swift */,
 				18FCC4472C37E4560052500D /* Assets.xcassets */,
@@ -394,10 +396,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ExamplesForSwiftUI/ExamplesForSwiftUI.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ExamplesForSwiftUI/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = VHY32ZU4KA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -413,12 +416,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cybozu.swiftui.examples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,3";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Debug;
 		};
@@ -427,10 +430,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ExamplesForSwiftUI/ExamplesForSwiftUI.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ExamplesForSwiftUI/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = VHY32ZU4KA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -446,12 +450,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cybozu.swiftui.examples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,3";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
 			};
 			name = Release;
 		};

--- a/Examples/ExamplesForSwiftUI/ExamplesForSwiftUI.entitlements
+++ b/Examples/ExamplesForSwiftUI/ExamplesForSwiftUI.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "LicenseList",
     platforms: [
         .iOS(.v15),
+        .macCatalyst(.v15),
         .tvOS(.v17),
     ],
     products: [

--- a/Plugins/PrepareLicenseList/main.swift
+++ b/Plugins/PrepareLicenseList/main.swift
@@ -34,10 +34,19 @@ struct PrepareLicenseList: BuildToolPlugin {
 
     // This command works with the plugin specified in `Package.swift`.
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let sourcePackagesPath = try sourcePackages(context.pluginWorkDirectory)
+        // Workaround for Mac Catalyst
+        let debugMacCatalystPath = sourcePackagesPath.removingLastComponent()
+            .appending(["Build", "Products", "Debug-maccatalyst"])
+        let executablePath: Path = if FileManager.default.fileExists(atPath: debugMacCatalystPath.string) {
+            debugMacCatalystPath.appending(["spp"])
+        } else {
+            try context.tool(named: "spp").path
+        }
         return [
             makeBuildCommand(
-                executablePath: try context.tool(named: "spp").path,
-                sourcePackagesPath: try sourcePackages(context.pluginWorkDirectory),
+                executablePath: executablePath,
+                sourcePackagesPath: sourcePackagesPath,
                 outputPath: context.pluginWorkDirectory
             )
         ]


### PR DESCRIPTION
close #34 

**Overview**

In iOS, directories called `Debug` and `Debug-iphonesimulator` are created in the `Build/Products` directory, and it is known that the `spp` binary file is placed in both of them.
However, in the case of Mac Catalyst, only the `Debug-maccatalyst` directory is created in `Build/Products`.
Even though the path of `context.tool(named: "spp")` is `Debug/spp`.
As a result, the plugin fails to run on Mac Catalyst because the `spp` binary file cannot be found.

**Related Issues**

- [Swift Package Plugin Context Tool Path is bugged when building for Mac Catalyst](https://developer.apple.com/forums/thread/740174)
- [Can't build for macCatalyst SPM(library, plugin, executable)](https://github.com/swiftlang/swift-package-manager/issues/6619)

This bug seems to be unfixed in Xcode 16.2. 🤮

**How to fix**

I verified whether the following API could be used, but found it to be of no use.

- `#if targetEnvironment(macCatalyst)`
- `ProcessInfo.processInfo.environment["IS_MACCATALYST"] == "YES"`
- `ProcessInfo.processInfo.isMacCatalystApp`

So I added a workaround to check in FileManager whether the `Debug-maccatalyst` directory exists.