### PR TITLE
Changed to be able to get SourcePackages path regardless of build system type.

### DIFF
--- a/Plugins/PrepareLicenseList/main.swift
+++ b/Plugins/PrepareLicenseList/main.swift
@@ -13,10 +13,9 @@ struct PrepareLicenseList: BuildToolPlugin {
         }
         do {
             let isDirectory = try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory!
-            let containsSourcePackages = try FileManager.default
-                .contentsOfDirectory(atPath: url.absoluteURL.path())
-                .contains("SourcePackages")
-            return isDirectory && containsSourcePackages
+            let existsSourcePackagesInDirectory = FileManager.default
+                .fileExists(atPath: url.appending(path: "SourcePackages").path())
+            return isDirectory && existsSourcePackagesInDirectory
         } catch {
             throw SourcePackagesNotFoundError()
         }

--- a/Plugins/PrepareLicenseList/main.swift
+++ b/Plugins/PrepareLicenseList/main.swift
@@ -27,7 +27,6 @@ struct PrepareLicenseList: BuildToolPlugin {
 
         while try !checkConditions(of: tmpURL) {
             tmpURL.deleteLastPathComponent()
-            print(tmpURL.absoluteString)
         }
         tmpURL.append(path: "SourcePackages")
         return tmpURL


### PR DESCRIPTION
I realized that we needed to use `FileManager` to get the `SourcePackages` directory path because the `DerivedData` directory structure differs depending on the build system.

| Build Tool | Version | pluginWorkDirectoryURL                                                                                                                                 |
| :--------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
| Xcode      | 16.2-   | `~derivedDataPath/ProjectName-XXXX/SourcePackages/plugins/licenselist.output/LicenseList/PrepareLicenseList/`                                   |
| xcodebuild | 16.2-   | `~derivedDataPath/SourcePackages/plugins/licenselist.output/LicenseList/PrepareLicenseList/`                                                    |
| Xcode      | 16.3+   | `~derivedDataPath/ProjectName-XXXX/Build/Intermediates.noindex/BuildToolPluginIntermediates/licenselist.output/LicenseList/PrepareLicenseList/` |
| xcodebuild | 16.3+   | `~derivedDataPath/Build/Intermediates.noindex/BuildToolPluginIntermediates/licenselist.output/LicenseList/PrepareLicenseList/`                  |

`~derivedDataPath` is `~/Library/Developer/Xcode/DerivedData/` in Xcode, and the path specified with `-derivedDataPath` in `xcodebuild`.