### PR TITLE
Make it possible to specify the SourcePackages path

### DIFF
--- a/Plugins/PrepareLicenseList/main.swift
+++ b/Plugins/PrepareLicenseList/main.swift
@@ -19,6 +19,10 @@ struct PrepareLicenseList: BuildToolPlugin {
     }
 
     func sourcePackages(_ pluginWorkDirectory: URL) throws -> URL {
+        if let sourcePackagesPath = ProcessInfo.processInfo.environment["PLL_SOURCE_PACKAGES_PATH"] {
+            return URL(filePath: sourcePackagesPath)
+        }
+
         var tmpURL = pluginWorkDirectory.absoluteURL
 
         while try !existsSourcePackages(in: tmpURL) {

--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ struct ContentView: View {
 }
 ```
 
+### How to use a specific `SourcePackages` path
+
+In a CI environment, you may sometimes specify a non-default path for the `SourcePackages` directory.  
+For example: `xcodebuild ... -clonedSourcePackagesDirPath ./SourcePackages`
+
+In such cases, to prevent the `PrepareLicenseList` plugin from failing, you must run `xcodebuild` with the `PLL_SOURCE_PACKAGES_PATH` environment variable set to the **absolute path** of that directory.
+
+For example:
+
+```sh
+export PLL_SOURCE_PACKAGES_PATH="$PWD/SourcePackages"
+xcodebuild clean build \
+  -project Examples/Examples.xcodeproj \
+  -scheme ExamplesForSwiftUI \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" \
+  -clonedSourcePackagesDirPath ./SourcePackages
+```
+
 ## Contributing to LicenseList
 
 Contributions to LicenseList are welcomed and encouraged! Please see the [Contributing Guide](/CONTRIBUTING.md).


### PR DESCRIPTION
In a CI environment, you may sometimes specify a non-default path for the SourcePackages directory.
For example: `xcodebuild ... -clonedSourcePackagesDirPath ./SourcePackages`
In that case, the build will fail because the `PrepareLicenseList` plugin cannot resolve the path to the source packages.

This change makes it possible to avoid this problem by specifying an environment variable in advance.